### PR TITLE
Remove harmful `mod' key in exif.app.src

### DIFF
--- a/src/exif.app.src
+++ b/src/exif.app.src
@@ -7,6 +7,5 @@
         kernel,
         stdlib
     ]},
-    {mod, {exif, []}},
     {env, []}
 ]}.


### PR DESCRIPTION
There is no supervision tree and the presence of `mod' may cause an
error:

=CRASH REPORT==== 10-Jun-2018::22:45:44.231548 ===
  crasher:
    initial call: application_master:init/4
    pid: <0.442.0>
    registered_name: []
    exception exit: {bad_return,
                        {{exif,start,[normal,[]]},
                         {'EXIT',
                             {undef,
                                 [{exif,start,[normal,[]],[]},
                                  {application_master,start_it_old,4,
                                      [{file,"application_master.erl"},
                                       {line,273}]}]}}}}
      in function  application_master:init/4 (application_master.erl, line 134)
    ancestors: [<0.441.0>]
    message_queue_len: 1
    messages: [{'EXIT',<0.443.0>,normal}]
    links: [<0.441.0>,<0.42.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 610
    stack_size: 27
    reductions: 242
  neighbours: