### PR TITLE
Maps support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-* [Erlang/OTP](http://www.erlang.org) R16 or higher
+* [Erlang/OTP](http://www.erlang.org) R16 or higher (17 or higher for EXIF in maps)
 * [rebar](https://github.com/rebar/rebar) 2.x
 
 To build the application and run the test suite, use `rebar` like so:
@@ -26,10 +26,15 @@ To add `erlang-exif` as a dependency to your rebar-based project, simply add the
 
 ## Example
 
-The `exif:read/1` function returns `{ok, Exif}` where `Exif` is a `dict:dict()` of the values read from the JPEG image. If no such values are present, the `dict` will be empty. However, if there was an error, an `{error, Reason}` tuple will be returned, where `Reason` is nearly always `invalid_exif`.
+The `exif:read(Path)` function actually calls `exif:read(Path, dict)` (for backward compatibility).
+
+The `exif:read(Path, ReturnType)` function returns `{ok, Exif}` where `Exif` is a `dict:dict()` or a map of the values read from the JPEG image.
+`ReturnType` has two valid values: `dict` and `maps`.
+If no such values are present, the structure will be empty.
+However, if there was an error, an `{error, Reason}` tuple will be returned, where `Reason` is nearly always `invalid_exif`.
 
 ```
-case exif:read(Path) of
+case exif:read(Path, dict) of
     {error, Reason} ->
         error_logger:error_msg("Unable to read EXIF data from ~s, ~p~n", [Path, Reason]);
     {ok, ExifData} ->
@@ -42,3 +47,6 @@ case exif:read(Path) of
         end
 end.
 ```
+
+Two more functions are present: `exif:read_binary/1` and `exif:read_binary/2` which are equivalents of `exif:read/1,2`.
+They accept actual file in binary format as a first argument, instead of a path.

--- a/rebar.config
+++ b/rebar.config
@@ -2,11 +2,11 @@
 %% rebar configuration file (https://github.com/rebar/rebar)
 %%
 
-{require_min_otp_vsn, "17"}.
+{require_min_otp_vsn, "R16"}.
 
 {erl_opts, [
-  debug_info,
-  fail_on_warning
+  {platform_define, "^[0-9]+", otp17_or_higher},
+  debug_info, fail_on_warning
  ]
 }.
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,11 +2,11 @@
 %% rebar configuration file (https://github.com/rebar/rebar)
 %%
 
-{require_min_otp_vsn, "R16"}.
+{require_min_otp_vsn, "17"}.
 
 {erl_opts, [
-  {platform_define, "^[0-9]+", namespaced_dicts},
-  debug_info, fail_on_warning
+  debug_info,
+  fail_on_warning
  ]
 }.
 

--- a/src/exif.erl
+++ b/src/exif.erl
@@ -11,8 +11,8 @@
 %% -------------------------------------------------------------------
 
 -module(exif).
--export([read/1]).
--export([read_binary/1]).
+-export([read/1, read/2]).
+-export([read_binary/1, read_binary/2]).
 
 -ifdef(debug).
 -define(DEBUG(Fmt, Args), io:format(Fmt, Args)).
@@ -20,11 +20,10 @@
 -define(DEBUG(_Fmt, _Args), ok).
 -endif.
 
--ifdef(namespaced_dicts).
--type exif_dict() :: dict:dict().
--else.
--type exif_dict() :: dict().
--endif.
+-type exif() :: dict:dict() | map().
+
+-type data_module() :: exif_dict | exif_maps.
+-type return_type() :: dict | maps.
 
 -define(MAX_EXIF_LEN,        65536).
 -define(JPEG_MARKER,       16#ffd8).
@@ -57,49 +56,85 @@
 %%
 -spec read_binary(Data) -> {ok, Exif} | {error, Reason}
     when Data   :: binary(),
-         Exif   :: exif_dict(),
+         Exif   :: exif(),
          Reason :: term().
-read_binary(Data) when is_binary(Data) ->
+read_binary(Data) ->
+    read_binary(Data, dict).
+
+%%
+%% @doc Read the Exif data from a binary and specify
+%%      a data module.
+%%
+-spec read_binary(Data, ReturnType) -> {ok, Exif} | {error, Reason}
+    when Data       :: binary(),
+         ReturnType :: return_type(),
+         Exif       :: exif(),
+         Reason     :: term().
+read_binary(Data, ReturnType) when is_binary(Data) ->
     ImageData = if byte_size(Data) > ?MAX_EXIF_LEN ->
                         <<Img:?MAX_EXIF_LEN/binary, _/binary>> = Data,
                         Img;
                    true ->
                         Data
                 end,
-    read(ImageData).
+    read(ImageData, data_mod(ReturnType)).
 
 %%
 %% @doc Read the Exif data from a named file (or binary data).
 %%
 -spec read(File) -> {ok, Exif} | {error, Reason}
     when File   :: list(),
-         Exif   :: exif_dict(),
+         Exif   :: exif(),
          Reason :: term()
         ; (Data) -> {ok, Exif} | {error, Reason}
     when Data   :: binary(),
-         Exif   :: exif_dict(),
+         Exif   :: exif(),
          Reason :: term().
 read(File) when is_list(File) ->
+    read(File, dict).
+
+%%
+%% @doc Read the Exif data from a named file (or binary data)
+%%      with data module specified.
+%%
+-spec read(File, ReturnType) -> {ok, Exif} | {error, Reason}
+    when File       :: list(),
+         ReturnType :: return_type(),
+         Exif       :: exif(),
+         Reason     :: term()
+        ; (Data, ReturnType) -> {ok, Exif} | {error, Reason}
+    when Data       :: binary(),
+         ReturnType :: return_type(),
+         Exif       :: exif(),
+         Reason     :: term().
+read(File, ReturnType) when is_list(File) ->
     {ok, Fd} = file:open(File, [read, binary, raw]),
     {ok, Img} = file:read(Fd, ?MAX_EXIF_LEN),
     ok = file:close(Fd),
-    read(Img);
+    read(Img, data_mod(ReturnType));
 
-read(<< ?JPEG_MARKER:16, ?JFIF_MARKER:16, Len:16, Rest/binary >>) ->
+
+read(<< ?JPEG_MARKER:16, ?JFIF_MARKER:16, Len:16, Rest/binary >>, DataMod) ->
     % skip the JFIF segment and attempt to match the Exif segment
     case skip_segment(Len, Rest) of
         <<?EXIF_MARKER:16, _Len:16, Exif/binary>> ->
-            read_exif(Exif);
+            read_exif(Exif, DataMod);
         _ ->
             % apparently just JFIF and no Exif
-            {ok, dict:new()}
+            {ok, DataMod:new()}
     end;
-read(<< ?JPEG_MARKER:16, ?EXIF_MARKER:16, _Len:16, Rest/binary >>) ->
-    read_exif(Rest);
-read(<< ?JPEG_MARKER:16, _Rest/binary >>) ->
-    {ok, dict:new()};
-read(_) ->
-    {ok, dict:new()}.
+read(<< ?JPEG_MARKER:16, ?EXIF_MARKER:16, _Len:16, Rest/binary >>, DataMod) ->
+    read_exif(Rest, DataMod);
+read(<< ?JPEG_MARKER:16, _Rest/binary >>, DataMod) ->
+    {ok, DataMod:new()};
+read(_, DataMod) ->
+    {ok, DataMod:new()}.
+
+-spec data_mod(ReturnType) -> DataMod
+    when ReturnType :: return_type(),
+         DataMod :: data_module().
+data_mod(dict) -> exif_dict;
+data_mod(maps) -> exif_maps.
 
 skip_segment(Len, Data) ->
     Skip = Len - 2,
@@ -111,9 +146,9 @@ read_exif(<<
             "Exif",
             0 : 16,
             TiffMarker/binary
-        >>) ->
-    read_tiff_marker(TiffMarker);
-read_exif(_) ->
+        >>, DataMod) ->
+    read_tiff_marker(TiffMarker, DataMod);
+read_exif(_, _) ->
     {error, invalid_exif}.
 
 read_tiff_marker(<<
@@ -121,37 +156,37 @@ read_tiff_marker(<<
              16#2a00   : 16,
              Offset    : 4/binary,
              _/binary
-          >> = TiffMarker) ->
-    read_exif_header(little, Offset, TiffMarker);
+          >> = TiffMarker, DataMod) ->
+    read_exif_header(little, Offset, TiffMarker, DataMod);
 read_tiff_marker(<< 16#4d4d   : 16,
              16#002a   : 16,
              Offset    : 4/binary,
              _/binary
-          >> = TiffMarker) ->
-    read_exif_header(big, Offset, TiffMarker);
-read_tiff_marker(_) ->
+          >> = TiffMarker, DataMod) ->
+    read_exif_header(big, Offset, TiffMarker, DataMod);
+read_tiff_marker(_, _DataMod) ->
     {error, invalid_exif}.
 
-read_exif_header(End, Offset, TiffMarker) ->
+read_exif_header(End, Offset, TiffMarker, DataMod) ->
     IfdOffset = uread(Offset, End),
     ?DEBUG("IFD0 at ~p~n", [IfdOffset]),
     <<_:IfdOffset/binary, IFD/binary>> = TiffMarker,
-    {ok, read_tags(IFD, TiffMarker, End, fun image_tag/1)}.
+    {ok, read_tags(IFD, TiffMarker, End, fun image_tag/1, DataMod)}.
 
-read_tags(<< NumEntries:2/binary, Rest/binary >>, TiffMarker, End, TagFun) ->
+read_tags(<< NumEntries:2/binary, Rest/binary >>, TiffMarker, End, TagFun, DataMod) ->
     N = uread(NumEntries, End),
-    read_tags(Rest, N, TiffMarker, End, TagFun).
+    read_tags(Rest, N, TiffMarker, End, TagFun, DataMod).
 
-read_tags(Bin, NumEntries, TiffMarker, End, TagFun) ->
-    read_tags(Bin, NumEntries, TiffMarker, End, TagFun, dict:new()).
+read_tags(Bin, NumEntries, TiffMarker, End, TagFun, DataMod) ->
+    read_tags(Bin, NumEntries, TiffMarker, End, TagFun, DataMod:new(), DataMod).
 
-read_tags(_Bin, 0, _TiffMarker, _End, _TagFun, Tags) ->
+read_tags(_Bin, 0, _TiffMarker, _End, _TagFun, Tags, _DataMod) ->
     Tags;
-read_tags(Bin, NumEntries, TiffMarker, End, TagFun, Tags) ->
-    {NewTags, Rest} = add_tag(Bin, TiffMarker, End, Tags, TagFun),
-    read_tags(Rest, NumEntries - 1, TiffMarker, End, TagFun, NewTags).
+read_tags(Bin, NumEntries, TiffMarker, End, TagFun, Tags, DataMod) ->
+    {NewTags, Rest} = add_tag(Bin, TiffMarker, End, Tags, TagFun, DataMod),
+    read_tags(Rest, NumEntries - 1, TiffMarker, End, TagFun, NewTags, DataMod).
 
-add_tag(<< Tag:2/binary, Rest/binary >>, TiffMarker, End, Tags, TagFun) ->
+add_tag(<< Tag:2/binary, Rest/binary >>, TiffMarker, End, Tags, TagFun, DataMod) ->
     TagNum = uread(Tag, End),
     Name = TagFun(TagNum),
     Value = tag_value(Name, read_tag_value(Rest, TiffMarker, End)),
@@ -164,23 +199,23 @@ add_tag(<< Tag:2/binary, Rest/binary >>, TiffMarker, End, Tags, TagFun) ->
                 unknown ->
                     Tags;
                 exif ->
-                    ExifTags = read_subtags(Value, TiffMarker, End, fun exif_tag/1),
-                    dict:merge(fun(_K, _ImageTag, ExifTag) -> ExifTag end, Tags, ExifTags);
+                    ExifTags = read_subtags(Value, TiffMarker, End, fun exif_tag/1, DataMod),
+                    DataMod:merge(Tags, ExifTags);
                 gps ->
-                    GpsTags = read_subtags(Value, TiffMarker, End, fun gps_tag/1),
-                    dict:merge(fun(_K, _ImageTag, GpsTag) -> GpsTag end, Tags, GpsTags);
+                    GpsTags = read_subtags(Value, TiffMarker, End, fun gps_tag/1, DataMod),
+                    DataMod:merge(Tags, GpsTags);
                 _ ->
-                    dict:store(Name, Value, Tags)
+                    DataMod:store(Name, Value, Tags)
             end
     end,
     Len = ?FIELD_LEN - 2, % 2 bytes for the tag above.
     << _:Len/binary, NewRest/binary >> = Rest,
     {NewTags, NewRest}.
 
-read_subtags(Offset, TiffMarker, End, TagFun) ->
+read_subtags(Offset, TiffMarker, End, TagFun, DataMod) ->
     ?DEBUG("Sub-IFD at ~p~n", [Offset]),
     << _:Offset/binary, Rest/binary >> = TiffMarker,
-    read_tags(Rest, TiffMarker, End, TagFun).
+    read_tags(Rest, TiffMarker, End, TagFun, DataMod).
 
 read_tag_value(<<
                  ValueType   : 2/binary,

--- a/src/exif_dict.erl
+++ b/src/exif_dict.erl
@@ -1,0 +1,19 @@
+-module(exif_dict).
+
+-export([new/0, merge/2, store/3, size/1, find/2]).
+
+new() ->
+    dict:new().
+
+merge(Dict1, Dict2) ->
+    dict:merge(fun(_K, _V1, V2) -> V2 end, Dict1, Dict2).
+
+store(K, V, Dict) ->
+    dict:store(K, V, Dict).
+
+size(Dict) ->
+    dict:size(Dict).
+
+find(Key, Dict) ->
+    dict:find(Key, Dict).
+

--- a/src/exif_maps.erl
+++ b/src/exif_maps.erl
@@ -2,6 +2,8 @@
 
 -export([new/0, merge/2, store/3, size/1, find/2]).
 
+-ifdef(otp17_or_higher).
+
 new() ->
     #{}.
 
@@ -17,3 +19,16 @@ size(Map) ->
 find(Key, Map) ->
     maps:find(Key, Map).
 
+-else.
+
+new() -> throw(maps_not_available).
+
+merge(_Map1, _Map2) -> throw(maps_not_available).
+
+store(_K, _V, _Map) -> throw(maps_not_available).
+
+size(_Map) -> throw(maps_not_available).
+
+find(_Key, _Map) -> throw(maps_not_available).
+
+-endif.

--- a/src/exif_maps.erl
+++ b/src/exif_maps.erl
@@ -1,0 +1,19 @@
+-module(exif_maps).
+
+-export([new/0, merge/2, store/3, size/1, find/2]).
+
+new() ->
+    #{}.
+
+merge(Map1, Map2) ->
+    maps:merge(Map1, Map2).
+
+store(K, V, Map) ->
+    Map#{ K => V }.
+
+size(Map) ->
+    maps:size(Map).
+
+find(Key, Map) ->
+    maps:find(Key, Map).
+

--- a/test/exif_SUITE.erl
+++ b/test/exif_SUITE.erl
@@ -17,8 +17,8 @@
 
 all() ->
     [
-     {group, dict},
-     {group, maps}
+     {group, dict}
+     | maybe_maps_tests()
     ].
 
 groups() ->
@@ -35,6 +35,16 @@ all_tests() ->
         test_ifd_end,
         test_empty_tag
     ].
+
+-ifdef(otp17_or_higher).
+
+maybe_maps_tests() ->  [{group, maps}].
+
+-else.
+
+maybe_maps_tests() -> [].
+
+-endif.
 
 %% ------------------------------------------------------------
 %% Init & clean
@@ -102,8 +112,9 @@ test_read_jfif_exif(Config) ->
 
 test_ifd_end(Config) ->
     DataDir = ?config(data_dir, Config),
+    ReturnType = ?config(return_type, Config),
     ImagePath = filename:join([DataDir, "ifd_end.jpg"]),
-    {ok, _Exif} = exif:read(ImagePath),
+    {ok, _Exif} = exif:read(ImagePath, ReturnType),
     ok.
 
 test_empty_tag(Config) ->


### PR DESCRIPTION
This PR adds `exif:read/2` function, which may return parsed EXIF not only as dict but also a map.